### PR TITLE
Remove primaryAgentPoolProfiles parameter

### DIFF
--- a/parameters.bicepparam
+++ b/parameters.bicepparam
@@ -3,15 +3,6 @@ using 'br/public:avm/res/container-service/managed-cluster:0.10.0'
 param name = 'avm-aks-cluster-abc'
 param location = 'belgiumcentral'
 
-param primaryAgentPoolProfiles = [
-  {
-    name: 'systempool'
-    mode: 'System'
-    vmSize: 'Standard_DS2_v2'
-    count: 1
-  }
-]
-
 param managedIdentities = {
   systemAssigned: true
 }


### PR DESCRIPTION
Removed primaryAgentPoolProfiles parameter from the configuration.