### PR TITLE
Update README for clarity on AVM usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AKS deployment (AVM)
 
-This folder contains an AKS deployment using Azure Verified Modules (AVM).
+This folder contains an AKS deployment using Azure Verified Modules.
 
 Files:
 - `main.bicep` - AVM-based AKS cluster module call


### PR DESCRIPTION
This pull request makes a minor wording update to the `README.md` file, clarifying the description of the AKS deployment by removing the abbreviation "AVM" from the title.